### PR TITLE
The first Windows fix, removing the shebang

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 SysInfTool v1.0
 MIT License, 2023


### PR DESCRIPTION
As part of a movement to improve compatibility with NT-based operating systems like Windows, this patch removes the shebang.